### PR TITLE
Use new provider columns

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -63,8 +63,8 @@ class AlertsController < ApplicationController
     params.require(:alert).permit(
       :id,
       :name,
-      :subregion_name,
-      :subregion_id,
+      :provider_search_name,
+      :provider_search_id,
       conditions_attributes: %i[id source field comparator value _destroy]
     )
   end

--- a/app/controllers/subregion_controller.rb
+++ b/app/controllers/subregion_controller.rb
@@ -31,11 +31,11 @@ class SubregionController < ApplicationController
     response = Alerts::SurflineProvider.new.search(params[:query])
     return ['Error! Does not compute!', ''] unless response.code == 200
 
-    subregion_response = response.parsed_response[1]
-    subregion_hits = subregion_response.dig('hits', 'hits') || []
-    subregion_hits.map do |subregion_hit|
-      name = subregion_hit.dig('_source', 'name')
-      id = subregion_hit.dig('_source', 'href').split('/')[5] # https://www.surfline.com/surf-forecasts/south-san-diego/58581a836630e24c4487900d
+    spot_response = response.parsed_response[0]
+    spot_hits = spot_response.dig('hits', 'hits') || []
+    spot_hits.map do |spot_hit|
+      name = spot_hit.dig('_source', 'name')
+      id = spot_hit.dig('_source', 'href').split('/')[5] # https://www.surfline.com/surf-forecasts/south-san-diego/58581a836630e24c4487900d
 
       [name, id]
     end

--- a/app/controllers/subregion_controller.rb
+++ b/app/controllers/subregion_controller.rb
@@ -35,7 +35,7 @@ class SubregionController < ApplicationController
     spot_hits = spot_response.dig('hits', 'hits') || []
     spot_hits.map do |spot_hit|
       name = spot_hit.dig('_source', 'name')
-      id = spot_hit.dig('_source', 'href').split('/')[5] # https://www.surfline.com/surf-forecasts/south-san-diego/58581a836630e24c4487900d
+      id = spot_hit.dig('_source', 'href').split('/')[5] # https://www.surfline.com/surf-report/sandspit/5842041f4e65fad6a7708966
 
       [name, id]
     end

--- a/app/javascript/controllers/subregion_controller.js
+++ b/app/javascript/controllers/subregion_controller.js
@@ -37,8 +37,10 @@ export default class extends Controller {
 
     const $subregionSelect = document.getElementById("subregion_select");
     const $selection = $subregionSelect.selectedOptions[0];
-    const $subregionName = document.getElementById("alert_subregion_name");
-    const $subregionId = document.getElementById("alert_subregion_id");
+    const $subregionName = document.getElementById(
+      "alert_provider_search_name"
+    );
+    const $subregionId = document.getElementById("alert_provider_search_id");
 
     $subregionName.value = $selection.text;
     $subregionId.value = $selection.value;

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -21,7 +21,7 @@
 #
 
 class Alert < ApplicationRecord
-  validates :name, :subregion_id, :subregion_name, presence: true
+  validates :name, :provider_search_id, :provider_search_name, presence: true
 
   strip_attributes
 

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -8,12 +8,12 @@
 #  name                 :string           not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  subregion_id         :string           not null
+#  subregion_id         :string
 #  user_id              :bigint           not null
-#  subregion_name       :string           not null
+#  subregion_name       :string
 #  provider_type        :string           default("surfline_spot"), not null
-#  provider_search_id   :string
-#  provider_search_name :string
+#  provider_search_id   :string           not null
+#  provider_search_name :string           not null
 #
 # Indexes
 #

--- a/app/views/alerts/_form.html.erb
+++ b/app/views/alerts/_form.html.erb
@@ -21,14 +21,14 @@
 
     <div class="field is-grouped" >
       <div class="control">
-        <%= form.text_field :subregion_name, class: 'input', readonly: true %>
+        <%= form.text_field :provider_search_name, class: 'input', readonly: true %>
       </div>
       <div class="control">
         <button class="button is-light" data-action="click->subregion#open">Search</button>
       </div>
     </div>
 
-    <%= form.hidden_field :subregion_id %>
+    <%= form.hidden_field :provider_search_id %>
   </div>
 
   <div id="conditions" class="mb-2">

--- a/app/views/alerts/_form.html.erb
+++ b/app/views/alerts/_form.html.erb
@@ -17,7 +17,7 @@
   </div>
 
   <div id="subregion" data-controller="subregion">
-    <label class="label">Subregion</label>
+    <label class="label">Spot</label>
 
     <div class="field is-grouped" >
       <div class="control">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -22,7 +22,7 @@
   <div class="container content">
     <h3 class="is-size-3">How do I use it?</h3>
     <p>
-      Surfmon is built around "alerts" and "conditions". You create an alert for a subregion then build
+      Surfmon is built around "alerts" and "conditions". You create an alert for a spot then build
       out the conditions you want to trigger an email. On Sunday afternoon (6PM PST/7PM PDT), Surfmon will send you an email with a list of
       alerts and the days their conditions are met.
     </p>

--- a/app/views/subregion/open.turbo_stream.erb
+++ b/app/views/subregion/open.turbo_stream.erb
@@ -5,7 +5,7 @@
       <div class="box">
         <div class="field" >
           <div class="control">
-            <input type="text" class="input" placeholder="Search for a subregion..." data-action="input->subregion#search" />
+            <input type="text" class="input" placeholder="Search for a spot..." data-action="input->subregion#search" />
           </div>
         </div>
 

--- a/db/migrate/20220829052044_remove_not_null_on_subregion_columns.rb
+++ b/db/migrate/20220829052044_remove_not_null_on_subregion_columns.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveNotNullOnSubregionColumns < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :alerts, :subregion_id, true
+    change_column_null :alerts, :subregion_name, true
+  end
+end

--- a/db/migrate/20220829052329_add_not_null_on_provider_columns.rb
+++ b/db/migrate/20220829052329_add_not_null_on_provider_columns.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddNotNullOnProviderColumns < ActiveRecord::Migration[7.0]
+  def change
+    # small table
+    safety_assured do
+      change_column_null :alerts, :provider_search_id, false
+      change_column_null :alerts, :provider_search_name, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_052911) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_29_052329) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,12 +18,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_052911) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "subregion_id", null: false
+    t.string "subregion_id"
     t.bigint "user_id", null: false
-    t.string "subregion_name", null: false
+    t.string "subregion_name"
     t.string "provider_type", default: "surfline_spot", null: false
-    t.string "provider_search_id"
-    t.string "provider_search_name"
+    t.string "provider_search_id", null: false
+    t.string "provider_search_name", null: false
     t.index ["user_id"], name: "index_alerts_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,8 +5,8 @@ users = [{ email: 'dudebro@example.com' }, { email: 'surfchick@example.com' }]
 alerts = [
   {
     name: 'Decent SB',
-    subregion_name: 'Santa Barbara',
-    subregion_id: '58581a836630e24c44878fd4',
+    provider_search_name: 'Rincon',
+    provider_search_id: '5842041f4e65fad6a7708814',
     conditions_attributes: [
       {
         source: 'conditions',
@@ -24,8 +24,8 @@ alerts = [
   },
   {
     name: 'Good ventucky',
-    subregion_name: 'Ventura',
-    subregion_id: '58581a836630e24c4487900c',
+    provider_search_name: 'Ventura Point',
+    provider_search_id: '584204204e65fad6a77096b1',
     conditions_attributes: [
       {
         source: 'conditions',
@@ -37,8 +37,8 @@ alerts = [
   },
   {
     name: 'Complexly good SB',
-    subregion_name: 'Santa Barbara',
-    subregion_id: '58581a836630e24c44878fd4',
+    provider_search_name: 'Rincon',
+    provider_search_id: '5842041f4e65fad6a7708814',
     conditions_attributes: [
       {
         source: 'wave',

--- a/lib/alerts/digest_data_generator.rb
+++ b/lib/alerts/digest_data_generator.rb
@@ -63,7 +63,7 @@ module Alerts
     def build_source_cache(alert)
       alert.conditions.pluck(:source).each_with_object({}) do |source_name, cache|
         source_class = configuration.source_klass(source_name).constantize
-        source = source_class.new(alert.subregion_id)
+        source = source_class.new(alert.provider_search_id)
         source.load
         cache[source_name] = source
 

--- a/lib/alerts/providers/surfline_provider.rb
+++ b/lib/alerts/providers/surfline_provider.rb
@@ -11,14 +11,14 @@ module Alerts
       self.class.get('/search/site', options)
     end
 
-    def conditions(subregion_id)
-      options = { query: { subregionId: subregion_id, days: 8 }, headers: headers }
+    def conditions(spot_id)
+      options = { query: { spotId: spot_id, days: 8 }, headers: headers }
 
       self.class.get('/kbyg/regions/forecasts/conditions', options)
     end
 
-    def wave(subregion_id)
-      options = { query: { subregionId: subregion_id, days: 8 }, headers: headers }
+    def wave(spot_id)
+      options = { query: { spotId: spot_id, days: 8 }, headers: headers }
 
       self.class.get('/kbyg/regions/forecasts/wave', options)
     end

--- a/lib/alerts/providers/surfline_provider.rb
+++ b/lib/alerts/providers/surfline_provider.rb
@@ -12,13 +12,13 @@ module Alerts
     end
 
     def conditions(spot_id)
-      options = { query: { spotId: spot_id, days: 8 }, headers: headers }
+      options = { query: { spotId: spot_id, days: 7 }, headers: headers }
 
       self.class.get('/kbyg/regions/forecasts/conditions', options)
     end
 
     def wave(spot_id)
-      options = { query: { spotId: spot_id, days: 8 }, headers: headers }
+      options = { query: { spotId: spot_id, days: 7 }, headers: headers }
 
       self.class.get('/kbyg/regions/forecasts/wave', options)
     end

--- a/lib/alerts/sources/base_source.rb
+++ b/lib/alerts/sources/base_source.rb
@@ -4,8 +4,8 @@ module Alerts
   class SourceError < StandardError; end
 
   class BaseSource
-    def initialize(subregion_id)
-      @subregion_id = subregion_id
+    def initialize(spot_id)
+      @spot_id = spot_id
     end
 
     def load
@@ -14,6 +14,6 @@ module Alerts
 
     private
 
-    attr_reader :subregion_id
+    attr_reader :spot_id
   end
 end

--- a/lib/alerts/sources/conditions_source.rb
+++ b/lib/alerts/sources/conditions_source.rb
@@ -37,7 +37,7 @@ module Alerts
 
     def conditions
       @conditions ||= begin
-        response = SurflineProvider.new.conditions(subregion_id)
+        response = SurflineProvider.new.conditions(spot_id)
         raise Alerts::SourceError, 'Received a non-200 code from surfline' unless response.code == 200
 
         response.parsed_response.dig('data', 'conditions')

--- a/lib/alerts/sources/wave_source.rb
+++ b/lib/alerts/sources/wave_source.rb
@@ -25,7 +25,7 @@ module Alerts
 
     def wave
       @wave ||= begin
-        response = SurflineProvider.new.wave(subregion_id)
+        response = SurflineProvider.new.wave(spot_id)
         raise Alerts::SourceError, 'Received a non-200 code from surfline' unless response.code == 200
 
         response.parsed_response.dig('data', 'wave')

--- a/test/fixtures/alerts.yml
+++ b/test/fixtures/alerts.yml
@@ -1,17 +1,17 @@
 good_sb:
   user: dudebro
   name: Really good SB
-  subregion_name: Santa Barbara
-  subregion_id: 58581a836630e24c44878fd4
+  provider_search_name: Rincon
+  provider_search_id: 5842041f4e65fad6a7708814
 
 decent_sb:
   user: dudebro
   name: Decent SB
-  subregion_name: Santa Barbara
-  subregion_id: 58581a836630e24c44878fd4
+  provider_search_name: Rincon
+  provider_search_id: 5842041f4e65fad6a7708814
 
 complexly_good_sb:
   user: dudebro
   name: Complexly good SB
-  subregion_name: Santa Barbara
-  subregion_id: 58581a836630e24c44878fd4
+  provider_search_name: Rincon
+  provider_search_id: 5842041f4e65fad6a7708814


### PR DESCRIPTION
Use backfilled provider columns, set them when searching, search for surfline spots instead of subregions, etc.

All to prep for multiple providers.